### PR TITLE
Add support for Render

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -11,6 +11,7 @@ node index.js
 And then you can visit;
 
 * `localhost:3000/` to see the welcome message
+* `localhost:3000/json` to see a json representation of the welcome message
 * `localhost:3000/image?file=cat.jpeg` to see the cat
 
 You can also manupulate the welcome message by setting the
@@ -18,13 +19,15 @@ You can also manupulate the welcome message by setting the
 
 ----
 
-These two endpoints are implemented in terms of three actions:
+These three endpoints are implemented in terms of four actions:
 
 1. `actions/session.js` - Assigns some state to `res.locals` based on a header.
    This is an example of using the `Next` response type.
-2. `actions/welcome.js` - Responds with some JSON based on the state set by
+2. `actions/welcome.js` - Responds with some HTLM based on the `index.hbs` file in
+   the `views` folder and some template data, using the `Render` response type. You can use any express view-engine. See example of view-engine configuration in `index.js.`
+3. `actions/welcomeJson.js` - Responds with some JSON based on the state set by
    the session middleware. This is an example of using previously defined state
    and using the `Json` response type.
-3. `actions/image.js` - Responds with a requested image. This is a more
+4. `actions/image.js` - Responds with a requested image. This is a more
    involved example showing asynchronous processing, using the `Stream`
    response type and handling error cases.

--- a/example/actions/image.js
+++ b/example/actions/image.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const {Stream} = require ('../..');
 const Future = require ('fluture');
 const fs = require ('fs');

--- a/example/actions/session.js
+++ b/example/actions/session.js
@@ -1,8 +1,8 @@
 const {Next} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) =>
-  Future.resolve
-    (Next
-      (Object.assign
-        ({session: {id: req.headers['x-authenticated-user']}}, locals)));
+module.exports = (req, locals) => {
+  const session = {id: req.headers['x-authenticated-user']};
+  const newLocals = Object.assign ({session}, locals);
+  return Future.resolve (Next (newLocals));
+};

--- a/example/actions/session.js
+++ b/example/actions/session.js
@@ -1,8 +1,8 @@
-'use strict';
-
 const {Next} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => Future.resolve (Next (Object.assign ({
-  session: {id: req.headers['x-authenticated-user']},
-}, locals)));
+module.exports = (req, locals) =>
+  Future.resolve
+    (Next
+      (Object.assign
+        ({session: {id: req.headers['x-authenticated-user']}}, locals)));

--- a/example/actions/welcome.js
+++ b/example/actions/welcome.js
@@ -1,10 +1,7 @@
 const {Render} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) =>
-  Future.resolve (
-    Render (200)
-           ('index')
-           ({user: locals.session.id
-                        ? `user ${locals.session.id}`
-                        : 'stranger'}));
+module.exports = (req, locals) => {
+  const user = locals.session.id ? `user ${locals.session.id}` : 'stranger';
+  return Future.resolve (Render (200) ('index') ({user}))
+};

--- a/example/actions/welcome.js
+++ b/example/actions/welcome.js
@@ -1,8 +1,10 @@
-'use strict';
-
 const {Render} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => Future.resolve (Json (200) ({
-  welcome: locals.session.id ? `user ${locals.session.id}` : 'stranger',
-}));
+module.exports = (req, locals) =>
+  Future.resolve (
+    Render (200)
+           ('index')
+           ({user: locals.session.id
+                        ? `user ${locals.session.id}`
+                        : 'stranger'}));

--- a/example/actions/welcome.js
+++ b/example/actions/welcome.js
@@ -3,5 +3,5 @@ const Future = require ('fluture');
 
 module.exports = (req, locals) => {
   const user = locals.session.id ? `user ${locals.session.id}` : 'stranger';
-  return Future.resolve (Render (200) ('index') ({user}))
+  return Future.resolve (Render (200) ('index') ({user}));
 };

--- a/example/actions/welcomeJson.js
+++ b/example/actions/welcomeJson.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const {Render} = require ('../..');
+const {Json} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => Future.resolve (Json (200) ({
+module.exports = (req, locals) => Future.resolve (Json (200, {
   welcome: locals.session.id ? `user ${locals.session.id}` : 'stranger',
 }));

--- a/example/actions/welcomeJson.js
+++ b/example/actions/welcomeJson.js
@@ -1,9 +1,7 @@
 const {Json} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) =>
-  Future.resolve (
-    Json (200)
-         ({welcome: locals.session.id
-                      ? `user ${locals.session.id}`
-                      : 'stranger'}));
+module.exports = (req, locals) => {
+  const welcome = locals.session.id ? `user ${locals.session.id}` : 'stranger';
+  Future.resolve (Json (200) ({welcome}));
+};

--- a/example/actions/welcomeJson.js
+++ b/example/actions/welcomeJson.js
@@ -3,5 +3,5 @@ const Future = require ('fluture');
 
 module.exports = (req, locals) => {
   const welcome = locals.session.id ? `user ${locals.session.id}` : 'stranger';
-  Future.resolve (Json (200) ({welcome}));
+  return Future.resolve (Json (200) ({welcome}));
 };

--- a/example/actions/welcomeJson.js
+++ b/example/actions/welcomeJson.js
@@ -1,8 +1,9 @@
-'use strict';
-
 const {Json} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => Future.resolve (Json (200, {
-  welcome: locals.session.id ? `user ${locals.session.id}` : 'stranger',
-}));
+module.exports = (req, locals) =>
+  Future.resolve (
+    Json (200)
+         ({welcome: locals.session.id
+                      ? `user ${locals.session.id}`
+                      : 'stranger'}));

--- a/example/index.js
+++ b/example/index.js
@@ -5,8 +5,12 @@ const {dispatcher} = require ('..');
 const path = require ('path');
 const dispatch = dispatcher (path.resolve (__dirname, 'actions'));
 
+app.set ('view engine', 'hbs');
+app.set ('views', path.join (__dirname, 'views'));
+
 app.use (dispatch ('session'));
 app.get ('/', dispatch ('welcome'));
+app.get ('/json', dispatch ('welcomeJson'));
 app.get ('/image', dispatch ('image'));
 
 app.listen (3000);

--- a/example/views/index.hbs
+++ b/example/views/index.hbs
@@ -1,0 +1,10 @@
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome</title>
+</head>
+<body>
+  Welcome {{user}}
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ export const Json = code => value => (
 //. will be the response status code, the second is the path to the template
 //. file, and the third is the data to inject into the template. This uses
 //. Express' render method under the hood, so you can configure it globally
-//. with app.set ('view engine', engine) and app.set ('views', path).
+//. with `app.set ('view engine', engine)` and `app.set ('views', path)`.
 export const Render = code => view => data => (
   Response.Render (code, view, data)
 );

--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ const runAction = (name, action, req, res, next) => {
         res.status (code);
         res.json (json);
       },
+      Render: (code, view, data) => {
+        res.status (code);
+        res.render (view, data);
+      },
       Redirect: (code, url) => {
         res.redirect (code, url);
       },
@@ -141,6 +145,17 @@ export const Stream = code => mime => stream => (
 export const Json = code => value => (
   Response.Json (code, value)
 );
+
+//# Render :: Number -> String -> Object -> Response a
+//.
+//. Indicates a response to be rendered using a template. The first argument
+//. will be the response status code, the second is the path to the template
+//. file, and the third is the data to inject into the template. This uses
+//. Express' render method under the hood, so you can configure it globally
+//. with app.set ('view engine', engine) and app.set ('views', path).
+export const Render = code => view => data => (
+  Response.Render(code, view, data)
+)
 
 //# Redirect :: Number -> String -> Response a
 //.

--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ const runAction = (name, action, req, res, next) => {
 export const Response = daggy.taggedSum ('Response', {
   Stream: ['code', 'mime', 'stream'],
   Json: ['code', 'value'],
+  Render: ['code', 'view', 'data'],
   Redirect: ['code', 'url'],
   Empty: [],
   Next: ['locals'],
@@ -154,8 +155,8 @@ export const Json = code => value => (
 //. Express' render method under the hood, so you can configure it globally
 //. with app.set ('view engine', engine) and app.set ('views', path).
 export const Render = code => view => data => (
-  Response.Render(code, view, data)
-)
+  Response.Render (code, view, data)
+);
 
 //# Redirect :: Number -> String -> Response a
 //.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "fluture": "^12.0.0",
     "oletus": "^3.0.0",
     "rollup": "^2.0.0",
+    "hbs": "^4.0.4",
     "sanctuary-scripts": "^4.0.0",
     "sinon": "^9.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "codecov": "^3.2.0",
     "express": "^4.16.2",
     "fluture": "^12.0.0",
+    "hbs": "^4.0.4",
     "oletus": "^3.0.0",
     "rollup": "^2.0.0",
-    "hbs": "^4.0.4",
     "sanctuary-scripts": "^4.0.0",
     "sinon": "^9.0.0"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import Z from 'sanctuary-type-classes';
 import sinon from 'sinon';
 import test from 'oletus';
 
-import {Response, Stream, Json, Redirect, Empty, Next, middleware, dispatcher} from '../index.js';
+import {Response, Stream, Json, Render, Redirect, Empty, Next, middleware, dispatcher} from '../index.js';
 
 
 function eq(actual, expected) {
@@ -29,6 +29,10 @@ test ('Stream', () => {
 
 test ('Json', () => {
   eq (Response.Json.is (Json (200) ({})), true);
+});
+
+test ('Render', () => {
+  eq (Response.Render.is (Render (200) ('index') ({})), true);
 });
 
 test ('Redirect', () => {
@@ -113,6 +117,16 @@ test ('Json middleware', () => {
   eq (mockRes.status.args, [[200]]);
   eq (mockRes.json.args, [[{foo: 'bar'}]]);
   eq (mockNext.args, []);
+});
+
+test ('Render middleware', () => {
+  const mock = middleware (_ => resolve (Render (200) ('index') ({user: 'hello'})));
+  const mockRes = {status: methodSpy (), render: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[200]]);
 });
 
 test ('Stream middleware', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,7 @@ test ('Render middleware', () => {
   mock ({}, mockRes, mockNext);
 
   eq (mockRes.status.args, [[200]]);
+  eq (mockRes.render.args, [['index', {user: 'hello'}]]);
 });
 
 test ('Stream middleware', () => {


### PR DESCRIPTION
Add a new action called Render which will add support for view_engines and server-rendered HMTL pages. I have added handlebars to dev-dependencies to show an example.

I wasn't sure how you wanted the routes to be defined, so moved the old '/' to '/json' and added a new route for '/' that shows a server-rendered HTML page.

I have not provided any tests for this as I struggled to get the test framework running. (some local issues).