### PR TITLE
Rework part of the lib to be more versatile

### DIFF
--- a/example/actions/image.js
+++ b/example/actions/image.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const {Stream} = require ('../..');
+const {Stream, withType} = require ('../..');
 const Future = require ('fluture');
 const fs = require ('fs');
 const path = require ('path');
 
 const access = x => y => Future.node (c => fs.access (x, y, c));
 
-module.exports = req => Future.go (function* () {
+module.exports = _ => req => Future.go (function* () {
   if (!req.query.file) {
     yield Future.reject (
       new Error ('You need to provide a query named "file"')
@@ -24,7 +24,6 @@ module.exports = req => Future.go (function* () {
     (_ => new Error ('No read access to the requested file'))
     (access (file) (fs.constants.R_OK));
 
-  return Stream (200)
-                (path.extname (req.query.file))
-                (fs.createReadStream (file));
+  return withType (path.extname (req.query.file))
+                  (Stream (Future.encase (fs.createReadStream) (file)));
 });

--- a/example/actions/session.js
+++ b/example/actions/session.js
@@ -3,7 +3,7 @@
 const {Next} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => {
+module.exports = locals => req => {
   const session = {id: req.headers['x-authenticated-user']};
   const newLocals = Object.assign ({session}, locals);
   return Future.resolve (Next (newLocals));

--- a/example/actions/welcome.js
+++ b/example/actions/welcome.js
@@ -3,7 +3,7 @@
 const {Render} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => {
+module.exports = locals => _ => {
   const user = locals.session.id ? `user ${locals.session.id}` : 'stranger';
-  return Future.resolve (Render (200) ('index') ({user}));
+  return Future.resolve (Render ('index') ({user}));
 };

--- a/example/actions/welcomeJson.js
+++ b/example/actions/welcomeJson.js
@@ -3,7 +3,7 @@
 const {Json} = require ('../..');
 const Future = require ('fluture');
 
-module.exports = (req, locals) => {
+module.exports = locals => _ => {
   const welcome = locals.session.id ? `user ${locals.session.id}` : 'stranger';
-  return Future.resolve (Json (200) ({welcome}));
+  return Future.resolve (Json ({welcome}));
 };

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "nodejs": ">=8.0.0"
   },
   "dependencies": {
-    "daggy": "^1.2.0"
+    "daggy": "^1.4.0",
+    "sanctuary-type-classes": "^12.1.0"
   },
   "peerDependencies": {
-    "fluture": ">=12.0.0 <15.0.0"
+    "fluture": ">=13.0.0 <15.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
@@ -54,10 +55,12 @@
     "codecov": "^3.2.0",
     "express": "^4.16.2",
     "fluture": "^14.0.0",
+    "fluture-node": "^4.0.0",
     "hbs": "^4.0.4",
     "oletus": "^3.0.0",
     "rollup": "^2.0.0",
     "sanctuary-scripts": "^4.0.0",
+    "sanctuary-show": "^2.0.0",
     "sinon": "^10.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import pkg from './package.json';
 const dependencyNames = Array.prototype.concat.call (
   Object.keys (pkg.dependencies),
   Object.keys (pkg.peerDependencies),
-  ['fluture/index.js', 'path']
+  ['path']
 );
 
 export default {
@@ -15,8 +15,5 @@ export default {
     exports: 'named',
     interop: false,
     globals: {},
-    paths: {
-      'fluture/index.js': 'fluture',
-    },
   },
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,17 @@
 import assert from 'assert';
-import {resolve} from 'fluture/index.js';
+import {resolve} from 'fluture';
 import Z from 'sanctuary-type-classes';
 import sinon from 'sinon';
 import test from 'oletus';
+import {emptyStream} from 'fluture-node';
+import show from 'sanctuary-show';
 
-import {Response, Stream, Json, Render, Redirect, Empty, Next, middleware, dispatcher} from '../index.js';
+import * as lib from '../index.js';
 
 
 function eq(actual, expected) {
   assert.strictEqual (arguments.length, eq.length);
-  assert.strictEqual (Z.toString (actual), Z.toString (expected));
+  assert.strictEqual (show (actual), show (expected));
   assert.strictEqual (Z.equals (actual, expected), true);
 }
 
@@ -24,34 +26,89 @@ function throws(fn, expected) {
 }
 
 test ('Stream', () => {
-  eq (Response.Stream.is (Stream (200) ('jpeg') ({})), true);
+  eq (lib.Response.is (lib.Stream (emptyStream)), true);
+});
+
+test ('Text', () => {
+  eq (lib.Response.is (lib.Text ('')), true);
 });
 
 test ('Json', () => {
-  eq (Response.Json.is (Json (200) ({})), true);
+  eq (lib.Response.is (lib.Json (null)), true);
 });
 
 test ('Render', () => {
-  eq (Response.Render.is (Render (200) ('index') ({})), true);
+  eq (lib.Response.is (lib.Render ('') ('')), true);
 });
 
 test ('Redirect', () => {
-  eq (Response.Redirect.is (Redirect (200) ('example.com')), true);
+  eq (lib.Response.is (lib.Redirect ('')), true);
 });
 
 test ('Empty', () => {
-  eq (Response.Empty.is (Empty), true);
+  eq (lib.Response.is (lib.Empty), true);
 });
 
 test ('Next', () => {
-  eq (Response.Next.is (Next ({})), true);
+  eq (lib.Response.is (lib.Next (null)), true);
+});
+
+test ('withStatus', () => {
+  eq (lib.Response.is (lib.withStatus (201) (lib.Empty)), true);
+  eq (lib.withStatus (201) (lib.Next (null)), lib.Next (null));
+});
+
+test ('withType', () => {
+  eq (lib.Response.is (lib.withType ('json') (lib.Empty)), true);
+  eq (lib.withType ('json') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withLocation', () => {
+  eq (lib.Response.is (lib.withLocation ('/') (lib.Empty)), true);
+  eq (lib.withLocation ('/') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withLinks', () => {
+  eq (lib.Response.is (lib.withLinks ({foo: 'example.com'}) (lib.Empty)), true);
+  eq (lib.withLinks ({foo: 'example.com'}) (lib.Next (null)), lib.Next (null));
+});
+
+test ('withCookie', () => {
+  eq (lib.Response.is (lib.withCookie ({}) ('user') ('bob') (lib.Empty)), true);
+  eq (lib.withCookie ({}) ('user') ('bob') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withClearCookie', () => {
+  eq (lib.Response.is (lib.withClearCookie ({}) ('user') (lib.Empty)), true);
+  eq (lib.withClearCookie ({}) ('user') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withHeaderPart', () => {
+  eq (lib.Response.is (lib.withHeaderPart ('X-Answer') ('42') (lib.Empty)), true);
+  eq (lib.withHeaderPart ('X-Answer') ('42') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withHeader', () => {
+  eq (lib.Response.is (lib.withHeader ('X-Answer') ('42') (lib.Empty)), true);
+  eq (lib.withHeader ('X-Answer') ('42') (lib.Next (null)), lib.Next (null));
+});
+
+test ('withoutHeader', () => {
+  eq (lib.withoutHeader ('Content-Type') (lib.withType ('json') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('Location') (lib.withLocation ('/') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('Link') (lib.withLinks ({foo: 'example.com'}) (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('Set-Cookie') (lib.withCookie ({}) ('user') ('bob') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('Set-Cookie') (lib.withClearCookie ({}) ('user') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('X-Answer') (lib.withHeaderPart ('X-Answer') ('42') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('X-Answer') (lib.withHeader ('X-Answer') ('42') (lib.Empty)), lib.Empty);
+  eq (lib.withoutHeader ('X-Other') (lib.withHeader ('X-Answer') ('42') (lib.Empty)), lib.withHeader ('X-Answer') ('42') (lib.Empty));
 });
 
 test ('middleware', () => {
   /* eslint-disable prefer-arrow-callback */
-  const mock = middleware (function mock() { return resolve (Json (200) ({})); });
-  const mockNoFuture = middleware (function mock() { return null; });
-  const mockNoResponse = middleware (function mock() { return resolve (null); });
+  const mock = lib.middleware (function mock() { return _ => resolve (lib.Json ({})); });
+  const mockNoFuture = lib.middleware (function mock() { return _ => null; });
+  const mockNoResponse = lib.middleware (function mock() { return _ => resolve (null); });
   /* eslint-enable prefer-arrow-callback */
 
   eq (typeof mock, typeof mockNoFuture);
@@ -73,7 +130,7 @@ test ('middleware', () => {
 });
 
 test ('Next middleware', () => {
-  const mock = middleware (_ => resolve (Next ({foo: 'bar'})));
+  const mock = lib.middleware (_ => _ => resolve (lib.Next ({foo: 'bar'})));
   const mockRes = {status: sinon.spy (), json: sinon.spy ()};
   const mockNext = sinon.spy ();
 
@@ -85,7 +142,7 @@ test ('Next middleware', () => {
 });
 
 test ('Empty middleware', () => {
-  const mock = middleware (_ => resolve (Empty));
+  const mock = lib.middleware (_ => _ => resolve (lib.Empty));
   const mockRes = {status: methodSpy (), end: methodSpy ()};
   const mockNext = sinon.spy ();
 
@@ -97,61 +154,125 @@ test ('Empty middleware', () => {
 });
 
 test ('Redirect middleware', () => {
-  const mock = middleware (_ => resolve (Redirect (200) ('example.com')));
-  const mockRes = {redirect: sinon.spy ()};
+  const mock = lib.middleware (_ => _ => resolve (lib.Redirect ('example.com')));
+  const mockRes = {location: methodSpy (), status: methodSpy (), end: methodSpy ()};
   const mockNext = sinon.spy ();
 
   mock ({}, mockRes, mockNext);
 
-  eq (mockRes.redirect.args, [[200, 'example.com']]);
+  eq (mockRes.status.args, [[301]]);
+  eq (mockRes.location.args, [['example.com']]);
+  eq (mockRes.end.args, [[]]);
   eq (mockNext.args, []);
 });
 
 test ('Json middleware', () => {
-  const mock = middleware (_ => resolve (Json (200) ({foo: 'bar'})));
-  const mockRes = {status: methodSpy (), json: methodSpy ()};
+  const mock = lib.middleware (_ => _ => resolve (lib.Json ({foo: 'bar'})));
+  const mockRes = {type: methodSpy (), send: methodSpy ()};
   const mockNext = sinon.spy ();
 
   mock ({}, mockRes, mockNext);
 
-  eq (mockRes.status.args, [[200]]);
-  eq (mockRes.json.args, [[{foo: 'bar'}]]);
+  eq (mockRes.type.args, [['application/json']]);
+  eq (mockRes.send.args, [['{"foo":"bar"}']]);
   eq (mockNext.args, []);
 });
 
 test ('Render middleware', () => {
-  const mock = middleware (_ => resolve (Render (200) ('index') ({user: 'hello'})));
-  const mockRes = {status: methodSpy (), render: methodSpy ()};
+  const mock = lib.middleware (_ => _ => resolve (lib.Render ('index') ({user: 'hello'})));
+  const mockRes = {render: methodSpy ()};
   const mockNext = sinon.spy ();
 
   mock ({}, mockRes, mockNext);
 
-  eq (mockRes.status.args, [[200]]);
   eq (mockRes.render.args, [['index', {user: 'hello'}]]);
 });
 
 test ('Stream middleware', () => {
   const mockStream = {pipe: sinon.spy ()};
-  const mock = middleware (_ => resolve (Stream (201) ('jpeg') (mockStream)));
-  const mockRes = {status: methodSpy (), type: methodSpy ()};
+  const mock = lib.middleware (_ => _ => resolve (lib.Stream (resolve (mockStream))));
+  const mockRes = {type: methodSpy ()};
   const mockNext = sinon.spy ();
 
   mock ({}, mockRes, mockNext);
 
   eq (mockStream.pipe.args, [[mockRes]]);
-  eq (mockRes.status.args, [[201]]);
-  eq (mockRes.type.args, [['jpeg']]);
+  eq (mockNext.args, []);
+});
+
+test ('withLinks middleware', () => {
+  const mock = lib.middleware (_ => _ => resolve (lib.withLinks ({foo: 'bar'}) (lib.Empty)));
+  const mockRes = {status: methodSpy (), links: methodSpy (), end: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[204]]);
+  eq (mockRes.links.args, [[{foo: 'bar'}]]);
+  eq (mockRes.end.args, [[]]);
+  eq (mockNext.args, []);
+});
+
+test ('withCookie middleware', () => {
+  const mock = lib.middleware (_ => _ => resolve (lib.withCookie ({foo: 'bar'}) ('a') ('b') (lib.Empty)));
+  const mockRes = {status: methodSpy (), cookie: methodSpy (), end: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[204]]);
+  eq (mockRes.cookie.args, [['a', 'b', {foo: 'bar'}]]);
+  eq (mockRes.end.args, [[]]);
+  eq (mockNext.args, []);
+});
+
+test ('withClearCookie middleware', () => {
+  const mock = lib.middleware (_ => _ => resolve (lib.withClearCookie ({foo: 'bar'}) ('a') (lib.Empty)));
+  const mockRes = {status: methodSpy (), clearCookie: methodSpy (), end: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[204]]);
+  eq (mockRes.clearCookie.args, [['a', {foo: 'bar'}]]);
+  eq (mockRes.end.args, [[]]);
+  eq (mockNext.args, []);
+});
+
+test ('withHeaderPart middleware', () => {
+  const mock = lib.middleware (_ => _ => resolve (lib.withHeaderPart ('a') ('b') (lib.Empty)));
+  const mockRes = {status: methodSpy (), append: methodSpy (), end: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[204]]);
+  eq (mockRes.append.args, [['a', 'b']]);
+  eq (mockRes.end.args, [[]]);
+  eq (mockNext.args, []);
+});
+
+test ('withHeader middleware', () => {
+  const mock = lib.middleware (_ => _ => resolve (lib.withHeader ('a') ('b') (lib.Empty)));
+  const mockRes = {status: methodSpy (), set: methodSpy (), end: methodSpy ()};
+  const mockNext = sinon.spy ();
+
+  mock ({}, mockRes, mockNext);
+
+  eq (mockRes.status.args, [[204]]);
+  eq (mockRes.set.args, [['a', 'b']]);
+  eq (mockRes.end.args, [[]]);
   eq (mockNext.args, []);
 });
 
 test ('dispatcher', async () => {
-  const mock = dispatcher ('test') ('mock-action.js');
-  const mockRes = {status: methodSpy (), json: methodSpy ()};
+  const mock = lib.dispatcher ('test') ('mock-action.js');
+  const mockRes = {type: methodSpy (), send: methodSpy ()};
   const mockNext = sinon.spy ();
 
   await mock ({}, mockRes, mockNext);
 
-  eq (mockRes.status.args, [[200]]);
-  eq (mockRes.json.args, [[{foo: 'bar'}]]);
+  eq (mockRes.type.args, [['application/json']]);
+  eq (mockRes.send.args, [['{"foo":"bar"}']]);
   eq (mockNext.args, []);
 });

--- a/test/mock-action.js
+++ b/test/mock-action.js
@@ -1,4 +1,4 @@
-import {resolve} from 'fluture/index.js';
+import {resolve} from 'fluture';
 import {Json} from '../index.js';
 
-export default _ => resolve (Json (200) ({foo: 'bar'}));
+export default _ => _ => resolve (Json ({foo: 'bar'}));


### PR DESCRIPTION
This introduces some ideas that @voxbono and I worked out on Gitter a while ago. You might be interested @voxbono :)

The idea is that the constructors themselves don't take any headers or status code, but that they can be added via function calls afterwards:

```js
Json ({me: 'teapot'})
|> withStatus (418)
|> withHeader ('X-Powered-By') ('230 Volts')
```