### PR TITLE
Fix some issues with value equality

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ const runAction = (name, action, req, res, next) => {
         body.cata ({
           None: _ => res.end (),
           Send: data => res.send (data),
+          Json: data => res.json (data),
           Stream: fork (next) (it => it.pipe (res)),
           Render: (template, data) => res.render (template, data),
         });
@@ -205,12 +206,14 @@ deriveEq (Head);
 //. ```hs
 //. data Body a = None
 //.             | Send Any
+//.             | Json JsonValue
 //.             | Stream (Future a Readable)
 //.             | Render String Object
 //. ```
 export const Body = daggy.taggedSum ('Body', {
   None: [],
   Send: ['data'],
+  Json: ['data'],
   Stream: ['stream'],
   Render: ['template', 'data'],
 });
@@ -244,16 +247,15 @@ export const Text = value => Response.Respond (
   Body.Send (value),
 );
 
-//# Json :: Object -> Response a b
+//# Json :: JsonValue -> Response a b
 //.
 //. Indicates a JSON response.
 //.
 //. Uses a Content-Type of `application/json` unless overridden by
-//. [`withType`](#withType), [`withHeader`](#withHeader),
-//. or [`withoutHeader`](#withoutHeader).
+//. [`withType`](#withType), [`withHeader`](#withHeader).
 export const Json = value => Response.Respond (
-  [Head.Type ('application/json')],
-  Body.Send (JSON.stringify (value)),
+  [],
+  Body.Json (value),
 );
 
 //# Render :: String -⁠> Object -⁠> Response a b

--- a/scripts/doctest
+++ b/scripts/doctest
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo 'Skipping doctests: Dynmaic imports not supported :('
+echo 'Skipping doctests: Dynamic imports not supported :('

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,7 @@ function throws(fn, expected) {
 
 test ('Stream', () => {
   eq (lib.Response.is (lib.Stream (emptyStream)), true);
+  eq (lib.Stream (emptyStream), lib.Stream (emptyStream));
 });
 
 test ('Text', () => {
@@ -42,8 +43,8 @@ test ('Json', () => {
 });
 
 test ('Render', () => {
-  eq (lib.Response.is (lib.Render ('') ('')), true);
-  eq (lib.Render ('') (''), lib.Render ('') (''));
+  eq (lib.Response.is (lib.Render ('asd') ({a: 1})), true);
+  eq (lib.Render ('asd') ({a: 1}), lib.Render ('asd') ({a: 1}));
 });
 
 test ('Redirect', () => {


### PR DESCRIPTION
While updating to 5.0 I found my tests' assertions started failing for some of the Json values. These fixes should address that, and similar, problems.